### PR TITLE
fix: move globby to dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,8 @@
   "dependencies": {
     "@oclif/command": "^1",
     "@oclif/config": "^1",
-    "@oclif/plugin-help": "^2"
+    "@oclif/plugin-help": "^2",
+    "globby": "^8"
   },
   "devDependencies": {
     "@oclif/dev-cli": "^1",
@@ -18,7 +19,6 @@
     "chai": "^4",
     "eslint": "^5.5",
     "eslint-config-oclif": "^3.1",
-    "globby": "^8",
     "mocha": "^5",
     "nyc": "^13"
   },


### PR DESCRIPTION
When building this project using a CI tool, the package published would not run without globby being listed as a runtime dependency.